### PR TITLE
Fix correct Android version.

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,5 +1,5 @@
 const RunningFirefoxVersion = (navigator.userAgent.match(/Firefox\/([0-9.]+)/) || ["", "58.0"])[1];
-const RunningAndroidVersion = navigator.userAgent.match(/Android\s[0-9.]+/) || "Android 6.0";
+const RunningAndroidVersion = navigator.userAgent.match(/Android [0-9.]+/) || "Android 6.0";
 
 const ChromeMajorVersionToMimic = `${parseInt(RunningFirefoxVersion) + 4}.0.0.0`;
 

--- a/common.js
+++ b/common.js
@@ -1,5 +1,5 @@
 const RunningFirefoxVersion = (navigator.userAgent.match(/Firefox\/([0-9.]+)/) || ["", "58.0"])[1];
-const RunningAndroidVersion = navigator.userAgent.match(/Android\/[0-9.]+/) || "Android 6.0";
+const RunningAndroidVersion = navigator.userAgent.match(/Android\s[0-9.]+/) || "Android 6.0";
 
 const ChromeMajorVersionToMimic = `${parseInt(RunningFirefoxVersion) + 4}.0.0.0`;
 


### PR DESCRIPTION
Fix https://github.com/wisniewskit/google-search-fixer/issues/24. Android version UA in GeckoView is `Android 11`, not `Android/11`.