### PR TITLE
Fix for ipv4.google.com and ipv6.google.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -232,8 +232,8 @@
       "*://*.google.co.zw/*",
       "*://*.google.cat/*",
       "*://*.google.ng/*",
-      "*://*ipv4.google.com/*",
-      "*://*ipv6.google.com/*"
+      "*://*.ipv4.google.com/*",
+      "*://*.ipv6.google.com/*"
     ]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -231,7 +231,9 @@
       "*://*.google.co.zm/*",
       "*://*.google.co.zw/*",
       "*://*.google.cat/*",
-      "*://*.google.ng/*"
+      "*://*.google.ng/*",
+      "*://*ipv4.google.com/*",
+      "*://*ipv6.google.com/*"
     ]
   }]
 }


### PR DESCRIPTION
I am a proud user of this plugin in Firefox for Android but it is not working to https://ipv4.google.com and https://ipv6.google.com (Not changing the UI)

@wisniewskit 
Now, I am submitting a possible "fix" to the problem.